### PR TITLE
Added alerts configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
+
+# default owners
+* @celo-org/core-services

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,3 @@ jobs:
       - name: Run unit tests
         run: |
             yarn test:cov
-      - name: Run integration tests
-        run: |
-            yarn test:e2e

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "lint": "eslint src/",
     "test": "jest --runInBand --silent",
     "test:watch": "jest --runInBand --watch --silent",
-    "test:cov": "jest --coverage --runInBand --silent",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:cov": "jest --coverage --runInBand",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
     "@celo/base": "^1.0.0-beta3",
@@ -47,7 +47,9 @@
     "prettier": "^2.2.1",
     "serverless": "^2.15.0",
     "serverless-layers": "^2.3.3",
+    "serverless-plugin-aws-alerts": "^1.6.1",
     "serverless-plugin-typescript": "^1.1.9",
+    "serverless-sqs-alarms-plugin": "^0.1.7",
     "serverless-webpack": "^5.3.5",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.12",

--- a/serverless.yml
+++ b/serverless.yml
@@ -37,6 +37,8 @@ provider:
 frameworkVersion: '2'
 
 plugins:
+  - serverless-plugin-aws-alerts
+  - serverless-sqs-alarms-plugin
   - serverless-webpack
   - serverless-layers
 
@@ -57,7 +59,7 @@ functions:
           path: authorize
           method: POST
     environment:
-      AUTHORIZATION_EXPIRES_IN: 300000 # 5 minutes
+      AUTHORIZATION_EXPIRES_IN: ${self:custom.parameters.authorize.authorizationExpiresIn}
     package:
       include:
         - src/authorize/**
@@ -73,19 +75,24 @@ functions:
     package:
       include:
         - src/flush/**
+    alarms:
+      - name: functionDuration
+        threshold: ${self:custom.parameters.flush.expectedMaxAverageDuration}
 
 resources:
   Resources:
     StorageBucket:
       Type: AWS::S3::Bucket
       DependsOn:
-        - FileUpdatesQueue
-      DeletionPolicy: Retain
+        - FileUpdatesQueuePolicy
+      # Warning: when a stack gets removed, this bucket will NOT be removed as part of it,
+      # so subsequent deployments of the same stack would fail, it has to be removed manually
+      DeletionPolicy: Retain 
       Metadata:
         Comment: 'Secure metadata storage'
       Properties:
         AccessControl: Private
-        BucketName: ${self:service}-storage-${self:custom.stage}
+        BucketName: ${self:custom.parameters.storageBucket.name}
         CorsConfiguration:
           CorsRules:
             - AllowedMethods:
@@ -133,15 +140,15 @@ resources:
               - 'HEAD'
               - 'GET'
             Compress: false
-            DefaultTTL: 86400
+            DefaultTTL: ${self:custom.parameters.cdn.cacheDefaultTtl}
             ForwardedValues:
               Cookies:
                 Forward: 'none'
               Headers:
                 - 'Origin'
               QueryString: false
-            MaxTTL: 31536000
-            MinTTL: 86400
+            MaxTTL: ${self:custom.parameters.cdn.cacheMaxTtl}
+            MinTTL: ${self:custom.parameters.cdn.cacheMinTtl}
             TargetOriginId: !Sub 's3-origin-${StorageBucket}'
             ViewerProtocolPolicy: 'redirect-to-https'
           DefaultRootObject: 'index.html'
@@ -168,29 +175,19 @@ resources:
     FileUpdatesQueue:
       Type: AWS::SQS::Queue
       Properties:
-        QueueName:
-          Fn::Join:
-            - "-"
-            - - FileUpdatesQueue
-              - ${self:custom.stage}
-              - ${self:custom.region}
-        MessageRetentionPeriod: 14400
-        VisibilityTimeout: ${self:custom.timeouts.fileUpdatesVisibility}
+        QueueName: ${self:custom.parameters.queues.fileUpdates.name}
+        MessageRetentionPeriod: ${self:custom.parameters.queues.fileUpdates.messageRetentionPeriod}
+        VisibilityTimeout: ${self:custom.parameters.queues.fileUpdates.visibilityTimeout}
         RedrivePolicy:
           deadLetterTargetArn: !GetAtt FileUpdatesQueueDLQ.Arn
-          maxReceiveCount: 5
+          maxReceiveCount: ${self:custom.parameters.queues.fileUpdates.maxReceiveCount}
         Tags: ${self:custom.tags}
 
     FileUpdatesQueueDLQ:
       Type: AWS::SQS::Queue
       Properties:
-        MessageRetentionPeriod: 345600
-        QueueName:
-          Fn::Join:
-            - "-"
-            - - FileUpdatesQueueDLQ
-              - ${self:custom.stage}
-              - ${self:custom.region}
+        MessageRetentionPeriod: ${self:custom.parameters.queues.fileUpdates.dlqMessageRetentionPeriod}
+        QueueName: ${self:custom.parameters.queues.fileUpdates.dlqName}
         Tags: ${self:custom.tags}
 
     FileUpdatesQueuePolicy:
@@ -206,7 +203,11 @@ resources:
               Resource: "*"
               Condition:
                 ArnEquals:
-                  "aws:SourceArn": !Sub "arn:aws:s3:::${StorageBucket}"
+                  "aws:SourceArn":
+                    Fn::Join:
+                      - ""
+                      - - "arn:aws:s3:::"
+                        - ${self:custom.parameters.storageBucket.name} # predefined bucket name allows to get rid of the circular dependency bucket <> policy
         Queues:
           - !Ref FileUpdatesQueue
 
@@ -229,21 +230,34 @@ custom:
       Value: ${self:service}
     - Key: environment
       Value: ${self:custom.stage}
-  timeouts:
-    fileUpdatesVisibility: 30 # this should be always greater than the flush function timeout
   parameters:
-    auth:
-      memorySize: 256
-      timeout: 5
-      authCacheTtl: 30
     authorize:
       memorySize: 256
       timeout: 5
+      authorizationExpiresIn: 300000 # 5 minutes
     flush:
       memorySize: 256
       timeout: 5
       batchSize: 1000
       batchingWindow: 30
+      expectedMaxAverageDuration: 2000 # 2 seconds
+    cdn:
+      cacheDefaultTtl: 86400 # 1 day
+      cacheMinTtl: 86400 # 1 day
+      cacheMaxTtl: 31536000 # 1 year
+    queues:
+      fileUpdates:
+        name: FileUpdatesQueue-${self:custom.stage}-${self:custom.region}
+        dlqName: FileUpdatesQueueDLQ-${self:custom.stage}-${self:custom.region}
+        visibilityTimeout: 30 # this should be always greater than the flush function timeout
+        maxReceiveCount: 5
+        messageRetentionPeriod: 14400 # 4 hours
+        dlqMessageRetentionPeriod: 345600 # 4 days
+    storageBucket:
+      name: ${self:service}-storage-${self:custom.stage}
+    monitoring:
+      apiKey: ${opt:monitoringApiKey, 'api-key-missing'}
+      endpoint: https://alert.victorops.com/integrations/cloudwatch/20131130/alert/${self:custom.parameters.monitoring.apiKey}/Web
   webpack:
     includeModules: false
   serverless-layers:
@@ -253,3 +267,51 @@ custom:
     dependenciesPath: ./package.json
     packageManager: yarn
     layersDeploymentBucket: stokado-layers
+  # SQS alarms depend on the SNS topics created in the alerts section below
+  # please note that they are created only for some environments (stages)
+  # for other environments, the SQS alarms will be created but will not trigger
+  # actual alarms
+  sqs-alarms:
+    - queue: ${self:custom.parameters.queues.fileUpdates.name}
+      topic: ${self:service}-${self:custom.stage}-alerts-alarm
+      name: ${self:service}-${self:custom.stage}-high-number-of-messages-alarm
+      thresholds:
+        - 100
+    - queue: ${self:custom.parameters.queues.fileUpdates.dlqName}
+      topic: ${self:service}-${self:custom.stage}-alerts-alarm
+      name: ${self:service}-${self:custom.stage}-high-number-of-dlq-messages-alarm
+      thresholds:
+        - 1
+  alerts:
+    stages:
+      - mainnet
+      - baklava
+      - alfajores
+      - dev
+    dashboards: true
+    nameTemplate: $[functionName]-$[metricName]-alarm
+    prefixTemplate: $[stackName]
+    topics:
+      ok:
+        topic: ${self:service}-${self:custom.stage}-alerts-ok
+        notifications:
+        - protocol: https
+          endpoint: ${self:custom.parameters.monitoring.endpoint}
+      alarm:
+        topic: ${self:service}-${self:custom.stage}-alerts-alarm
+        notifications:
+        - protocol: https
+          endpoint: ${self:custom.parameters.monitoring.endpoint}
+      insufficientData:
+        topic: ${self:service}-${self:custom.stage}-alerts-insufficientData
+        notifications:
+        - protocol: https
+          endpoint: ${self:custom.parameters.monitoring.endpoint}
+    definitions:
+      functionErrors:
+        period: 300
+    alarms:
+      - functionThrottles
+      - functionErrors
+      - functionInvocations
+      - functionDuration

--- a/src/authorize/authorize.spec.ts
+++ b/src/authorize/authorize.spec.ts
@@ -36,10 +36,11 @@ describe('authorizer', () => {
 
   it('returns error if one of the paths is unknown', async () => {
     const result = await authorizer.authorize(
-      '[{"path": "/account/name"},{"path":"/something/random"}]',
+      '[{"path":"/something/random"},{"path": "/account/name"}]',
       expiresInSeconds,
       signer
     )
+
     expect(result.ok).toBe(false)
     if (result.ok === false) {
       expect(result.error.errorType).toEqual(AuthorizerErrorTypes.InvalidUploadPath)
@@ -48,10 +49,11 @@ describe('authorizer', () => {
 
   it('returns error if one of the paths is absent', async () => {
     const result = await authorizer.authorize(
-      '[{"path": "/account/name"},{"notpath":"/account/name.signature"}]',
+      '[{"notpath":"/account/name.signature"},{"path": "/account/name"}]',
       expiresInSeconds,
       signer
     )
+
     expect(result.ok).toBe(false)
     if (result.ok === false) {
       expect(result.error.errorType).toEqual(AuthorizerErrorTypes.InvalidUploadPath)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6942,7 +6942,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
-lodash@4.17.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
+lodash@4.17.x, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -8939,6 +8939,13 @@ serverless-layers@^2.3.3:
     semver "^7.3.2"
     slugify "^1.4.0"
 
+serverless-plugin-aws-alerts@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-aws-alerts/-/serverless-plugin-aws-alerts-1.6.1.tgz#433e0e781c6c49b29cb61f18bd72522beb06681e"
+  integrity sha512-ylw60cZkjDFtTR08eEKcIU5CHK0PD8TLmTERZ0V4Aoo7cDqT/a9Lr4Ke9U2yBabxrRRqCg1zzZ9QqtQL99YlZA==
+  dependencies:
+    lodash "^4.17.10"
+
 serverless-plugin-typescript@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/serverless-plugin-typescript/-/serverless-plugin-typescript-1.1.9.tgz#75348a93f3f5dae19aad7006d51a545618892028"
@@ -8947,6 +8954,13 @@ serverless-plugin-typescript@^1.1.9:
     fs-extra "^7.0.1"
     globby "^9.2.0"
     lodash "^4.17.11"
+
+serverless-sqs-alarms-plugin@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/serverless-sqs-alarms-plugin/-/serverless-sqs-alarms-plugin-0.1.7.tgz#d9858897cd2ba05cf89bc8f3909a01ed0668f591"
+  integrity sha1-2YWIl80roFz4m8jzkJoB7QZo9ZE=
+  dependencies:
+    lodash "^4.17.4"
 
 serverless-webpack@^5.3.5:
   version "5.3.5"


### PR DESCRIPTION
Adds alerts configuration (pretty strict right now for debugging purposes but that can be adjusted later):
* `>= 1 error in 5 minutes interval`
* `average duration > 500 ms for the `authorize` function, > 2 s for the `flush` function`
* `> 1 throttle event in 1 minute`
* `>= 1 message in the dead-letter queue`
* `> 100 messages available for the processing in any given minute in the file updates queue`

Includes integration with VictorOps.