### PR TITLE
Verifying the signature more explicitly

### DIFF
--- a/src/authorize/authorize.spec.ts
+++ b/src/authorize/authorize.spec.ts
@@ -11,15 +11,7 @@ describe('authorizer', () => {
   const authorizer = new Authorizer(s3, bucket)
 
   it('returns error for invalid json payload', async () => {
-    const result = await authorizer.authorize('{bad json', expiresInSeconds, signer)
-    expect(result.ok).toBe(false)
-    if (result.ok === false) {
-      expect(result.error.errorType).toEqual(AuthorizerErrorTypes.InvalidPayload)
-    }
-  })
-
-  it('returns error for non-array payload', async () => {
-    const result = await authorizer.authorize('{}', expiresInSeconds, signer)
+    const result = await authorizer.authorize(null, expiresInSeconds, signer)
     expect(result.ok).toBe(false)
     if (result.ok === false) {
       expect(result.error.errorType).toEqual(AuthorizerErrorTypes.InvalidPayload)
@@ -27,7 +19,7 @@ describe('authorizer', () => {
   })
 
   it('returns error for empty array payload', async () => {
-    const result = await authorizer.authorize('[]', expiresInSeconds, signer)
+    const result = await authorizer.authorize([], expiresInSeconds, signer)
     expect(result.ok).toBe(false)
     if (result.ok === false) {
       expect(result.error.errorType).toEqual(AuthorizerErrorTypes.InvalidPayload)
@@ -36,7 +28,7 @@ describe('authorizer', () => {
 
   it('returns error if one of the paths is unknown', async () => {
     const result = await authorizer.authorize(
-      '[{"path":"/something/random"},{"path": "/account/name"}]',
+      [{ path: '/something/random' }, { path: '/account/name' }],
       expiresInSeconds,
       signer
     )
@@ -48,11 +40,8 @@ describe('authorizer', () => {
   })
 
   it('returns error if one of the paths is absent', async () => {
-    const result = await authorizer.authorize(
-      '[{"notpath":"/account/name.signature"},{"path": "/account/name"}]',
-      expiresInSeconds,
-      signer
-    )
+    const paths = JSON.parse('[{"notpath": "/account/name.signature"}, {"path": "/account/name"}]')
+    const result = await authorizer.authorize(paths, expiresInSeconds, signer)
 
     expect(result.ok).toBe(false)
     if (result.ok === false) {
@@ -76,7 +65,7 @@ describe('authorizer', () => {
     })
 
     const newAuthorizer = new Authorizer(new AWS.S3(), bucket)
-    const result = await newAuthorizer.authorize(`[{"path": "${key}"}]`, expiresInSeconds, signer)
+    const result = await newAuthorizer.authorize([{ path: `${key}` }], expiresInSeconds, signer)
 
     expect(result.ok).toBe(true)
     AWSMock.restore('S3')

--- a/src/authorize/authorize.ts
+++ b/src/authorize/authorize.ts
@@ -25,6 +25,10 @@ export class InvalidUploadPathError extends RootError<AuthorizerErrorTypes.Inval
 
 export type AuthorizerError = InvalidPayloadError | InvalidUploadPathError
 
+export interface Path {
+  path: string
+}
+
 export class Authorizer {
   private readonly s3: AWS.S3
   private readonly bucketName: string
@@ -35,17 +39,10 @@ export class Authorizer {
   }
 
   authorize = async (
-    payload: string,
+    items: Path[],
     expires: number,
     signer: string
   ): Promise<Result<AWS.S3.PresignedPost[], AuthorizerError>> => {
-    let items = []
-    try {
-      items = JSON.parse(payload)
-    } catch (e) {
-      return Err(new InvalidPayloadError())
-    }
-
     if (!Array.isArray(items) || items.length === 0) {
       return Err(new InvalidPayloadError())
     }

--- a/src/authorize/bootstrap.ts
+++ b/src/authorize/bootstrap.ts
@@ -47,6 +47,7 @@ const handlerFactory = (authorizer: Authorizer, expiresIn: number): APIGatewayPr
       const guessedSigner = toChecksumAddress(guessSigner(payload, signature))
 
       if (claimedSigner !== guessedSigner) {
+        console.info(`Guessed signer ${guessedSigner} !== claimed signer ${claimedSigner}`)
         return response(403, 'Invalid signature provided')
       }
 

--- a/test/authorize.req.json
+++ b/test/authorize.req.json
@@ -13,7 +13,7 @@
     "CloudFront-Viewer-Country": "DE",
     "Content-Type": "application/json",
     "Host": "kel03d4ef0.execute-api.eu-west-1.amazonaws.com",
-    "Signature": "0xf94258ca073c0df9084d78bb11fb58a3a14b0e776dd06e1aa76e3a9b622aa0e51bbe45b84a15fffafeebbcab7cd86ed74f48e64c8758d5dc373abc8477f6922f01",
+    "Signature": "0x82e7beb4f72f875fc8f30da40d8d620823736525d001c36307edc3dae54bddca2803231a609e57c5f2c05290db30157da202904b726c08c61c374597abb47c7700",
     "User-Agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
     "Via": "1.1 e90965fc09a647100bac5d68d2d591f6.cloudfront.net (CloudFront)",
     "X-Amz-Cf-Id": "7rnxSlIixjVxbVi1CEYQk8eOLBSzFnzfrA-BAwDtAmLMrPnL_qdqSg==",
@@ -33,7 +33,7 @@
     "CloudFront-Viewer-Country": ["DE"],
     "Content-Type": ["application/json"],
     "Host": ["kel03d4ef0.execute-api.eu-west-1.amazonaws.com"],
-    "Signature": ["0xf94258ca073c0df9084d78bb11fb58a3a14b0e776dd06e1aa76e3a9b622aa0e51bbe45b84a15fffafeebbcab7cd86ed74f48e64c8758d5dc373abc8477f6922f01"],
+    "Signature": ["0x82e7beb4f72f875fc8f30da40d8d620823736525d001c36307edc3dae54bddca2803231a609e57c5f2c05290db30157da202904b726c08c61c374597abb47c7700"],
     "User-Agent": ["node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"],
     "Via": ["1.1 e90965fc09a647100bac5d68d2d591f6.cloudfront.net (CloudFront)"],
     "X-Amz-Cf-Id": ["7rnxSlIixjVxbVi1CEYQk8eOLBSzFnzfrA-BAwDtAmLMrPnL_qdqSg=="],
@@ -76,6 +76,6 @@
     "domainName": "kel03d4ef0.execute-api.eu-west-1.amazonaws.com",
     "apiId": "kel03d4ef0"
   },
-  "body": "[{\"path\": \"/account/name\"}, {\"path\": \"/account/name.signature\"}]",
+  "body": "{\"address\":\"0x1998cAfD892179aE648c71F9107fc9cc6A156155\",\"data\":[{\"path\":\"/account/name\"},{\"path\":\"/account/name.signature\"}]}",
   "isBase64Encoded": false
 }


### PR DESCRIPTION
**Description**
Fixes #6. Slightly changes the format of the expected payload. Previously, it expected an array of paths to sign:
```
[{"path": "/account/name"}]
```
This PR changes it to
```
{"address": "0xabcdef...", "data": [{"path": "/account/name"}]}
```
so the address can be explicitly verified using the signature.