### PR TITLE
Different address for signing and account

### DIFF
--- a/src/authorize/authorize.ts
+++ b/src/authorize/authorize.ts
@@ -41,7 +41,7 @@ export class Authorizer {
   authorize = async (
     items: Path[],
     expires: number,
-    signer: string
+    account: string
   ): Promise<Result<AWS.S3.PresignedPost[], AuthorizerError>> => {
     if (!Array.isArray(items) || items.length === 0) {
       return Err(new InvalidPayloadError())
@@ -66,7 +66,7 @@ export class Authorizer {
             return this.s3.createPresignedPost({
               Bucket: this.bucketName,
               Fields: {
-                key: `${signer}${path}`,
+                key: `${account}${path}`,
               },
               Expires: expires,
               Conditions: [

--- a/src/authorize/bootstrap.ts
+++ b/src/authorize/bootstrap.ts
@@ -41,9 +41,10 @@ const handlerFactory = (authorizer: Authorizer, expiresIn: number): APIGatewayPr
     }
 
     try {
-      const { address, data } = JSON.parse(payload)
+      const typedData = JSON.parse(payload)
+      const { signer, data, address } = typedData.message.payload
 
-      const claimedSigner = toChecksumAddress(address)
+      const claimedSigner = toChecksumAddress(signer)
       const guessedSigner = toChecksumAddress(guessSigner(payload, signature))
 
       if (claimedSigner !== guessedSigner) {
@@ -55,7 +56,7 @@ const handlerFactory = (authorizer: Authorizer, expiresIn: number): APIGatewayPr
         const signedUrls = await makeAsyncThrowable(authorizer.authorize)(
           data,
           expiresIn,
-          guessedSigner
+          toChecksumAddress(address)
         )
         return response(200, JSON.stringify(signedUrls))
       } catch (e) {

--- a/test/authorize.req.json
+++ b/test/authorize.req.json
@@ -76,6 +76,6 @@
     "domainName": "kel03d4ef0.execute-api.eu-west-1.amazonaws.com",
     "apiId": "kel03d4ef0"
   },
-  "body": "{\"address\":\"0x1998cAfD892179aE648c71F9107fc9cc6A156155\",\"data\":[{\"path\":\"/account/name\"},{\"path\":\"/account/name.signature\"}]}",
+  "body": "{\"address\":\"0x1998cAfD892179aE648c71F9107fc9cc6A156155\",\"signer\":\"0x17Dd1686F1B592C7d0869b439ddd1fCD669b352f\",\"data\":[{\"path\":\"/account/name\"},{\"path\":\"/account/name.signature\"}]}",
   "isBase64Encoded": false
 }


### PR DESCRIPTION
The account address used for the data path/URL may be different from the address of the signer