### PR TITLE
add signer key to payload and verify against DEK

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+FORNO_URL=https://staging-forno.celo-networks-dev.org
+AUTHORIZATION_EXPIRES_IN=300000
+BUCKET_NAME=stokado-storage-dev
+AWS_REGION=eu-west-1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,5 +55,8 @@ jobs:
         run: |
             yarn lint
       - name: Run unit tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
             yarn test:cov

--- a/envs.yaml
+++ b/envs.yaml
@@ -7,19 +7,23 @@ default_env: &default_env
 dev:
   <<: *default_env
   certificateId: "c6d0791a-0882-488b-bb3e-c4b4bdd1bd37"
+  fornoUrl: "https://staging-forno.celo-networks-dev.org"
   withCustomDomain: true
 
 alfajores:
   <<: *default_env
   certificateId: "b8b13459-2236-4850-a456-fd57b4ca4b7f"
+  fornoUrl: "https://alfajores-forno.celo-testnet.org"
   withCustomDomain: true
 
 baklava:
   <<: *default_env
   certificateId: "b8b13459-2236-4850-a456-fd57b4ca4b7f"
+  fornoUrl: "https://baklava-forno.celo-testnet.org"
   withCustomDomain: true
 
 rc1:
   <<: *default_env
   certificateId: "b8b13459-2236-4850-a456-fd57b4ca4b7f"
+  fornoUrl: "https://forno.celo.org"
   withCustomDomain: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   testEnvironment: 'node',
   coverageDirectory: './coverage',
   verbose: true,
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>'],
   collectCoverageFrom: ['**/*.{js,jsx}', '**/*.{ts,tx}', '!**/node_modules/**'],
   moduleNameMapper: {
     ...pathsToModuleNameMapper(compilerOptions.paths, {
@@ -18,4 +18,5 @@ module.exports = {
     'src/authorize/(.*)': '<rootDir>/src/authorize/$1',
     'src/flush/(.*)': '<rootDir>/src/authorize/$1',
   },
+  setupFiles: ["dotenv/config"],
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "^4.10.0",
     "aws-sdk": "^2.812.0",
     "aws-sdk-mock": "^5.1.0",
+    "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,6 +10,7 @@ provider:
   environment:
     BUCKET_NAME: !Ref StorageBucket
     CDN_DISTRIBUTION_ID: ${self:resources.Outputs.CloudFrontDistributionId.Value}
+    FORNO_URL: ${self:custom.envSpecificParams.fornoUrl}
   apiGateway:
     shouldStartNameWithService: true
   iam:
@@ -91,7 +92,7 @@ resources:
         - FileUpdatesQueuePolicy
       # Warning: when a stack gets removed, this bucket will NOT be removed as part of it,
       # so subsequent deployments of the same stack would fail, it has to be removed manually
-      DeletionPolicy: Retain 
+      DeletionPolicy: Retain
       Metadata:
         Comment: 'Secure metadata storage'
       Properties:
@@ -134,7 +135,7 @@ resources:
       Type: AWS::CloudFront::Distribution
       Metadata:
         Comment: 'Stokado service CloudFront distribution'
-      Properties: 
+      Properties:
         DistributionConfig:
           Aliases:
             # we can't reuse the domain name used by API Gateway due to the limitation of edge-optimized endpoints

--- a/src/authorize/handler.spec.ts
+++ b/src/authorize/handler.spec.ts
@@ -146,6 +146,28 @@ describe('authorizer handler', () => {
     }
   })
 
+  it('validates signer', async () => {
+    const payload = JSON.stringify({
+      address: kit.defaultAccount,
+      data: [{ path: 'foo' }],
+      signer: writerAddress,
+    })
+
+    const handler = getHandler()
+    const event = getEvent(payload, {
+      Signature: await getSignature(payload, kit),
+    })
+    const result = await handler(event, null, null)
+    console.log(result)
+
+    expect(result).not.toBeUndefined()
+
+    if (result) {
+      expect(result.statusCode).toBe(403)
+      expect(result.body).toBe('Invalid signer provided')
+    }
+  })
+
   it('handles valid payload', async () => {
     const payload = JSON.stringify({
       address: kit.defaultAccount,

--- a/src/authorize/handler.ts
+++ b/src/authorize/handler.ts
@@ -11,5 +11,6 @@ export const handle: APIGatewayProxyHandler = bootstrap(
   },
   process.env.AWS_REGION,
   parseInt(process.env.AUTHORIZATION_EXPIRES_IN, 10),
-  process.env.BUCKET_NAME
+  process.env.BUCKET_NAME,
+  process.env.FORNO_URL
 )

--- a/test/authorize.req.json
+++ b/test/authorize.req.json
@@ -13,7 +13,7 @@
     "CloudFront-Viewer-Country": "DE",
     "Content-Type": "application/json",
     "Host": "kel03d4ef0.execute-api.eu-west-1.amazonaws.com",
-    "Signature": "0x82e7beb4f72f875fc8f30da40d8d620823736525d001c36307edc3dae54bddca2803231a609e57c5f2c05290db30157da202904b726c08c61c374597abb47c7700",
+    "Signature": "0x60fc4b5845e9f74081b03217becf85386808f4d313138e9bd2cf3db3aca5d9b468fc1023a2e19b20c69d475b6d2f71d370c2c8ecb0111d1039a7e822105ae29201",
     "User-Agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
     "Via": "1.1 e90965fc09a647100bac5d68d2d591f6.cloudfront.net (CloudFront)",
     "X-Amz-Cf-Id": "7rnxSlIixjVxbVi1CEYQk8eOLBSzFnzfrA-BAwDtAmLMrPnL_qdqSg==",
@@ -33,7 +33,7 @@
     "CloudFront-Viewer-Country": ["DE"],
     "Content-Type": ["application/json"],
     "Host": ["kel03d4ef0.execute-api.eu-west-1.amazonaws.com"],
-    "Signature": ["0x82e7beb4f72f875fc8f30da40d8d620823736525d001c36307edc3dae54bddca2803231a609e57c5f2c05290db30157da202904b726c08c61c374597abb47c7700"],
+    "Signature": ["0x60fc4b5845e9f74081b03217becf85386808f4d313138e9bd2cf3db3aca5d9b468fc1023a2e19b20c69d475b6d2f71d370c2c8ecb0111d1039a7e822105ae29201"],
     "User-Agent": ["node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"],
     "Via": ["1.1 e90965fc09a647100bac5d68d2d591f6.cloudfront.net (CloudFront)"],
     "X-Amz-Cf-Id": ["7rnxSlIixjVxbVi1CEYQk8eOLBSzFnzfrA-BAwDtAmLMrPnL_qdqSg=="],
@@ -76,6 +76,6 @@
     "domainName": "kel03d4ef0.execute-api.eu-west-1.amazonaws.com",
     "apiId": "kel03d4ef0"
   },
-  "body": "{\"address\":\"0x1998cAfD892179aE648c71F9107fc9cc6A156155\",\"data\":[{\"path\":\"/account/name\"},{\"path\":\"/account/name.signature\"}]}",
+  "body": "{\"address\":\"0x1998cAfD892179aE648c71F9107fc9cc6A156155\",\"signer\":\"0x17Dd1686F1B592C7d0869b439ddd1fCD669b352f\",\"data\":[{\"path\":\"/account/name\"},{\"path\":\"/account/name.signature\"}]}",
   "isBase64Encoded": false
 }

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -1,0 +1,70 @@
+import * as event from './authorize.req.json'
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda/trigger/api-gateway-proxy'
+import { privateKeyToPublicKey, publicKeyToAddress } from '@celo/utils/lib/address'
+import FormData from 'form-data'
+import { ensureLeading0x } from '@celo/base'
+import fetch from 'node-fetch'
+import { handle } from '@app/authorize/handler'
+import { newKit } from '@celo/contractkit'
+
+describe('e2e test', () => {
+  it('adds an account, sets a DEK for the account and generates signature of event body', async () => {
+    // these values were then manually copied into authorize.req.json
+    const writerPrivate = '0xdcef435698f5d070035071541c14440fde752ea847d863d88418218f93ad5a1a'
+    const writerPublic = privateKeyToPublicKey(writerPrivate)
+    const writerAddress = publicKeyToAddress(writerPublic)
+    const writerEncryptionKeyPrivate =
+      '0xc029c933337a6a1b08fc75c56dfba605bfbece471c356923ef79056c5f0a2e81'
+    const writerEncryptionKeyPublic = privateKeyToPublicKey(writerEncryptionKeyPrivate)
+    const writerEncryptionKeyAddress = publicKeyToAddress(writerEncryptionKeyPublic)
+    const writerKit = newKit(process.env.FORNO_URL)
+    writerKit.addAccount(writerPrivate)
+    writerKit.addAccount(writerEncryptionKeyPrivate)
+    writerKit.defaultAccount = writerAddress
+    const hexPayload = ensureLeading0x(Buffer.from(event.body).toString('hex'))
+    const signature = await writerKit
+      .getWallet()
+      .signPersonalMessage(writerEncryptionKeyAddress, hexPayload)
+
+    const accounts = await writerKit.contracts.getAccounts()
+    await accounts
+      .setAccountDataEncryptionKey(writerEncryptionKeyPublic)
+      .sendAndWaitForReceipt({ from: writerAddress })
+
+    expect(signature).toBe(
+      '0x60fc4b5845e9f74081b03217becf85386808f4d313138e9bd2cf3db3aca5d9b468fc1023a2e19b20c69d475b6d2f71d370c2c8ecb0111d1039a7e822105ae29201'
+    )
+  })
+
+  it('gets a pre-signed post url, uses it to upload a string to s3 and checks that the string is correct', async () => {
+    // please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars by using the export command before running
+    const handleResponse = (await handle(
+      (event as unknown) as APIGatewayProxyEvent,
+      null,
+      null
+    )) as APIGatewayProxyResult
+    const preSignedPost = JSON.parse(handleResponse.body)[0]
+    const formData = new FormData()
+    const dataPayload = 'some random string'
+
+    Object.entries(preSignedPost.fields).forEach(([k, v]) => {
+      formData.append(k, v)
+    })
+    formData.append('file', dataPayload)
+
+    await fetch(preSignedPost.url, {
+      method: 'POST',
+      headers: {
+        enctype: 'multipart/form-data',
+      },
+      body: formData,
+    }).then((x) => x.text())
+
+    await new Promise((resolve) => setTimeout(resolve, 30000))
+
+    const getFileResponse = await fetch(
+      'https://dev-stokado-data.celo-testnet.org/0x17Dd1686F1B592C7d0869b439ddd1fCD669b352f/account/name'
+    )
+    expect(await getFileResponse.text()).toBe(dataPayload)
+  }, 35000)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "@app/flush/*": [
         "src/flush/*"
       ]
-    }
+    },
+    "resolveJsonModule": true
   },
   "include": ["./**/*.ts"],
   "exclude": [


### PR DESCRIPTION
We now expect next to the address, a signer key which is the writerEncryptionKeyAddress as part of the payload and compare it with the DEK associated with the passed address before sending back a presigned post URL.