### PR TITLE
Changed the way invalidation reference is generated

### DIFF
--- a/envs.yaml
+++ b/envs.yaml
@@ -38,4 +38,4 @@ rc1:
   authorize:
     expectedMaxAverageDuration: 3000
   flush:
-    expectedMaxAverageDuration: 20000
+    expectedMaxAverageDuration: 50000

--- a/serverless.yml
+++ b/serverless.yml
@@ -261,7 +261,7 @@ custom:
       expectedMaxAverageDuration: ${self:custom.envSpecificParams.authorize.expectedMaxAverageDuration}
     flush:
       memorySize: 256
-      timeout: 30
+      timeout: 50
       batchSize: 1000
       batchingWindow: 10
       expectedMaxAverageDuration: ${self:custom.envSpecificParams.flush.expectedMaxAverageDuration}

--- a/src/flush/bootstrap.ts
+++ b/src/flush/bootstrap.ts
@@ -37,7 +37,7 @@ const handlerFactory = (flusher: Flusher): SQSHandler => {
       throw new Error('Empty keys')
     }
 
-    const result = await flusher.flush(keys)
+    const result = await flusher.flush(keys, event.Records[0].messageId)
     console.debug(result)
   }
 }

--- a/src/flush/flush.spec.ts
+++ b/src/flush/flush.spec.ts
@@ -3,7 +3,7 @@ import AWSMock from 'aws-sdk-mock'
 import { Flusher } from './flush'
 
 describe('flush', () => {
-  it('creates invalidation reqeust', async () => {
+  it('creates invalidation request', async () => {
     const distributionId = 'distribution'
     const keys = ['/some/key']
 
@@ -14,7 +14,7 @@ describe('flush', () => {
       'createInvalidation',
       (params: AWS.CloudFront.Types.CreateInvalidationRequest, callback) => {
         expect(params.DistributionId).toBe(distributionId)
-        expect(params.InvalidationBatch.CallerReference).toContain('invalidation-')
+        expect(params.InvalidationBatch.CallerReference).toEqual('invalidation-unique-message-id')
         expect(params.InvalidationBatch.Paths.Quantity).toBe(1)
         expect(params.InvalidationBatch.Paths.Items).toEqual(keys)
         callback(null, expectedInvalidationResult)
@@ -24,7 +24,7 @@ describe('flush', () => {
     const cdn = new AWS.CloudFront()
 
     const flusher = new Flusher(cdn, distributionId)
-    const result = await flusher.flush(keys)
+    const result = await flusher.flush(keys, 'unique-message-id')
 
     expect(result).toBe(expectedInvalidationResult)
     AWSMock.restore('CloudFront')

--- a/src/flush/flush.ts
+++ b/src/flush/flush.ts
@@ -13,13 +13,14 @@ export class Flusher {
   }
 
   flush(
-    keys: string[]
+    keys: string[],
+    messageId: string
   ): Promise<PromiseResult<AWS.CloudFront.CreateInvalidationResult, AWS.AWSError>> {
     console.debug('Flushing the keys', keys)
 
     const invalidationRequest = this.createInvalidationRequest(
       keys,
-      this.getInvalidationReference(),
+      this.getInvalidationReference(messageId),
       this.distributionId
     )
     console.debug(invalidationRequest)
@@ -27,8 +28,8 @@ export class Flusher {
     return this.cdn.createInvalidation(invalidationRequest).promise()
   }
 
-  private getInvalidationReference(): string {
-    return `invalidation-${Date.now()}`
+  private getInvalidationReference(messageId: string): string {
+    return `invalidation-${messageId}`
   }
 
   private createInvalidationRequest(


### PR DESCRIPTION
## Motivation

Fixes #18.

Every path that needs to be invalidated is a different entry in the queue and when two messages arrive to the lambda at the same very microsecond, the uniqueness that is provided by the timestamp is not enough. Instead of relying on that, the unique message id can be used.

The call with the error:
![image](https://user-images.githubusercontent.com/20768968/121041286-e715be00-c7b2-11eb-8a56-6524d5c3e8e6.png)

The successful call:
![image](https://user-images.githubusercontent.com/20768968/121041418-04e32300-c7b3-11eb-8279-106b4a9b2a99.png)
